### PR TITLE
4 - Featured picture not showing on post page

### DIFF
--- a/themes/2020/layouts/post/single.html
+++ b/themes/2020/layouts/post/single.html
@@ -9,6 +9,11 @@
 
     <div class="measure">
       <article class="post-content">
+        {{ if .Params.thumbnail }}
+        <div class="post-image">
+          <img src="{{ .Params.thumbnail }}" />
+        </div>
+        {{ end }}
         {{ .Content }}
       </article>
 


### PR DESCRIPTION
Issue: https://github.com/alezucca/londonandnewcastle/issues/4

Updated post page:
![image](https://user-images.githubusercontent.com/429760/73430628-75b03a80-4336-11ea-9da6-e1371fd64f9c.png)
